### PR TITLE
Fix API endpoints and add missing tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "listmonk-mcp"
-version = "0.0.2"
+version = "0.0.3"
 description = "MCP server for Listmonk newsletter management"
 authors = [
     { name = "Rohan Verma", email = "hello@rohanverma.net" }

--- a/src/listmonk_mcp/client.py
+++ b/src/listmonk_mcp/client.py
@@ -270,8 +270,8 @@ class ListmonkClient:
 
     async def get_list_subscribers(self, list_id: int, page: int = 1, per_page: int = 20) -> dict[str, Any]:
         """Get subscribers for a specific list."""
-        params = {"page": page, "per_page": per_page}
-        return await self._request("GET", f"/api/lists/{list_id}/subscribers", params=params)
+        params = {"page": page, "per_page": per_page, "list_id": list_id}
+        return await self._request("GET", "/api/subscribers", params=params)
 
     # Campaign Operations
     async def get_campaigns(
@@ -328,14 +328,22 @@ class ListmonkClient:
         body: str | None = None,
         tags: list[str] | None = None
     ) -> dict[str, Any]:
-        """Update an existing campaign."""
-        data: dict[str, Any] = {}
+        """Update an existing campaign.
+
+        If lists is not provided, fetches the current campaign's lists to preserve them.
+        """
+        # If lists not provided, fetch current campaign to get existing lists
+        if lists is None:
+            current = await self.get_campaign(campaign_id)
+            campaign_data = current.get("data", {})
+            current_lists = campaign_data.get("lists", [])
+            lists = [lst.get("id") for lst in current_lists if lst.get("id")]
+
+        data: dict[str, Any] = {"lists": lists}
         if name is not None:
             data["name"] = name
         if subject is not None:
             data["subject"] = subject
-        if lists is not None:
-            data["lists"] = lists
         if body is not None:
             data["body"] = body
         if tags is not None:

--- a/src/listmonk_mcp/client.py
+++ b/src/listmonk_mcp/client.py
@@ -437,6 +437,91 @@ class ListmonkClient:
         }
         return await self._request("POST", "/api/tx", json_data=payload)
 
+    # Media Operations
+    async def get_media(self) -> dict[str, Any]:
+        """Get all media files."""
+        return await self._request("GET", "/api/media")
+
+    async def upload_media(self, file_path: str, title: str | None = None) -> dict[str, Any]:
+        """Upload a media file.
+
+        Args:
+            file_path: Absolute path to the file to upload
+            title: Optional title for the media file (defaults to filename)
+
+        Returns:
+            Dict containing the uploaded media data including URL
+        """
+        import os
+        from pathlib import Path
+
+        client = self._get_client()
+        url = self._build_url("/api/media")
+
+        file_path_obj = Path(file_path)
+        if not file_path_obj.exists():
+            raise ListmonkAPIError(f"File not found: {file_path}")
+
+        # Determine content type from file extension
+        content_types = {
+            '.jpg': 'image/jpeg',
+            '.jpeg': 'image/jpeg',
+            '.png': 'image/png',
+            '.gif': 'image/gif',
+            '.webp': 'image/webp',
+            '.svg': 'image/svg+xml',
+        }
+        ext = file_path_obj.suffix.lower()
+        content_type = content_types.get(ext, 'application/octet-stream')
+
+        # Use filename as title if not provided
+        if title is None:
+            title = file_path_obj.name
+
+        # Read file content
+        with open(file_path, 'rb') as f:
+            file_content = f.read()
+
+        # Prepare multipart form data
+        files = {
+            'file': (file_path_obj.name, file_content, content_type)
+        }
+        data = {}
+        if title:
+            data['title'] = title
+
+        try:
+            # Remove Content-Type header for multipart, httpx will set it automatically
+            headers = {
+                "Authorization": f"token {self.config.username}:{self.config.password}",
+                "User-Agent": "Listmonk-MCP-Server/0.1.0",
+                "Accept": "application/json",
+            }
+
+            response = await client.post(url, files=files, data=data, headers=headers)
+            return await self._handle_response(response)
+
+        except httpx.RequestError as e:
+            raise ListmonkAPIError(f"Media upload failed: {str(e)}") from e
+
+    async def update_media(self, media_id: int, title: str) -> dict[str, Any]:
+        """Update media file metadata (rename).
+
+        Args:
+            media_id: ID of the media file
+            title: New title for the media file
+        """
+        data = {"title": title}
+        return await self._request("PUT", f"/api/media/{media_id}", json_data=data)
+
+    async def delete_media(self, media_id: int) -> dict[str, Any]:
+        """Delete a media file.
+
+        Args:
+            media_id: ID of the media file to delete
+        """
+        return await self._request("DELETE", f"/api/media/{media_id}")
+
 
 async def create_client(config: Config) -> ListmonkClient:
     """Create and connect a Listmonk client."""

--- a/src/listmonk_mcp/client.py
+++ b/src/listmonk_mcp/client.py
@@ -396,14 +396,23 @@ class ListmonkClient:
         body: str | None = None,
         is_default: bool | None = None
     ) -> dict[str, Any]:
-        """Update an existing template."""
-        data: dict[str, Any] = {}
-        if name is not None:
-            data["name"] = name
-        if body is not None:
-            data["body"] = body
-        if is_default is not None:
-            data["is_default"] = is_default
+        """Update an existing template.
+
+        Fetches the current template first and merges changes, as Listmonk
+        requires all fields in PUT requests.
+        """
+        # Fetch current template to get all existing values
+        current = await self.get_template(template_id)
+        template_data = current.get("data", {})
+
+        # Build update data with current values as defaults
+        # IMPORTANT: type must be included, otherwise Listmonk validates as transactional template
+        data: dict[str, Any] = {
+            "name": name if name is not None else template_data.get("name", ""),
+            "type": template_data.get("type", "campaign"),
+            "body": body if body is not None else template_data.get("body", ""),
+            "is_default": is_default if is_default is not None else template_data.get("is_default", False),
+        }
 
         return await self._request("PUT", f"/api/templates/{template_id}", json_data=data)
 

--- a/src/listmonk_mcp/server.py
+++ b/src/listmonk_mcp/server.py
@@ -1137,6 +1137,149 @@ async def get_template_preview(template_id: str) -> str:
         return f"Error retrieving template content {template_id}: {str(e)}"
 
 
+# Media Management Tools
+@mcp.tool()
+async def get_media_list() -> str:
+    """
+    Get all media files from Listmonk.
+
+    Returns a list of all uploaded media with their IDs, filenames, URLs, and metadata.
+    """
+    async def _get_media_logic() -> str:
+        client = get_client()
+        result = await client.get_media()
+
+        data = result.get("data", [])
+
+        if not data:
+            return "No media files found."
+
+        media_items = []
+        for media in data:
+            created = media.get('created_at', 'Unknown')[:10]  # Just the date part
+            media_items.append(
+                f"- ID: {media.get('id')} | {media.get('filename')} | "
+                f"Title: {media.get('title', 'No title')} | "
+                f"Size: {media.get('size', 0)} bytes | "
+                f"Created: {created}\n"
+                f"  URL: {media.get('uri', 'No URL')}"
+            )
+
+        return f"Found {len(data)} media files:\n" + "\n".join(media_items)
+
+    return await safe_execute_async(_get_media_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def upload_media_file(
+    file_path: str,
+    title: str | None = None
+) -> str:
+    """
+    Upload a media file to Listmonk.
+
+    Args:
+        file_path: Absolute path to the image file to upload
+        title: Optional title/description for the media (defaults to filename)
+
+    Returns:
+        Success message with the uploaded file's URL
+    """
+    async def _upload_media_logic() -> str:
+        client = get_client()
+        result = await client.upload_media(file_path, title)
+
+        media_data = result.get("data", {})
+        media_id = media_data.get("id", "unknown")
+        uri = media_data.get("uri", "No URL")
+        filename = media_data.get("filename", "unknown")
+
+        return f"Successfully uploaded '{filename}' (ID: {media_id})\nURL: {uri}"
+
+    return await safe_execute_async(_upload_media_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def rename_media(media_id: int, new_title: str) -> str:
+    """
+    Rename/update the title of a media file.
+
+    Args:
+        media_id: ID of the media file to rename
+        new_title: New title/description for the media file
+
+    Returns:
+        Success message
+    """
+    async def _rename_media_logic() -> str:
+        client = get_client()
+        await client.update_media(media_id, new_title)
+
+        return f"Successfully renamed media {media_id} to '{new_title}'"
+
+    return await safe_execute_async(_rename_media_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def delete_media_file(media_id: int) -> str:
+    """
+    Delete a media file from Listmonk.
+
+    Args:
+        media_id: ID of the media file to delete
+
+    Returns:
+        Success message
+    """
+    async def _delete_media_logic() -> str:
+        client = get_client()
+        await client.delete_media(media_id)
+
+        return f"Successfully deleted media {media_id}"
+
+    return await safe_execute_async(_delete_media_logic)  # type: ignore[no-any-return]
+
+
+# Media Resources
+@mcp.resource("listmonk://media")
+async def list_media_files() -> str:
+    """List all media files with details."""
+    try:
+        client = get_client()
+        result = await client.get_media()
+
+        data = result.get("data", [])
+
+        if not data:
+            return "# Media Files\n\nNo media files found."
+
+        media_list = []
+        for media in data:
+            size_kb = media.get('size', 0) / 1024
+            created = media.get('created_at', 'Unknown')
+            media_list.append(
+                f"- **{media.get('filename')}** (ID: {media.get('id')})\n"
+                f"  - Title: {media.get('title', 'No title')}\n"
+                f"  - Size: {size_kb:.1f} KB\n"
+                f"  - Created: {created}\n"
+                f"  - URL: {media.get('uri', 'No URL')}"
+            )
+
+        media_items = "\n\n".join(media_list)
+
+        return f"""# Media Files
+
+**Total Files:** {len(data)}
+
+{media_items}
+
+*Use upload_media_file to add new files, rename_media to update titles, or delete_media_file to remove files.*
+"""
+
+    except ListmonkAPIError as e:
+        return f"Error retrieving media files: {str(e)}"
+
+
 # CLI application
 cli_app = typer.Typer(
     name="listmonk-mcp",

--- a/src/listmonk_mcp/server.py
+++ b/src/listmonk_mcp/server.py
@@ -309,7 +309,7 @@ async def get_mailing_lists() -> str:
     """
     Get all mailing lists.
 
-    Returns a list of all mailing lists with their IDs, names, subscriber counts, and types.
+    Returns a list of all mailing lists with their IDs, UUIDs, names, subscriber counts, and types.
     """
     async def _get_lists_logic() -> str:
         client = get_client()
@@ -325,6 +325,7 @@ async def get_mailing_lists() -> str:
         for lst in lists:
             list_items.append(
                 f"- ID: {lst.get('id')} | {lst.get('name')} | "
+                f"UUID: {lst.get('uuid')} | "
                 f"Subscribers: {lst.get('subscriber_count', 0)} | "
                 f"Type: {lst.get('type', 'unknown')}"
             )
@@ -490,6 +491,36 @@ async def get_campaigns(
         return f"Found {total} campaigns (showing {len(campaigns)}):\n" + "\n".join(campaign_items)
 
     return await safe_execute_async(_get_campaigns_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def get_campaign(campaign_id: int) -> str:
+    """
+    Get a specific campaign by ID including its full body content.
+
+    Args:
+        campaign_id: ID of the campaign to retrieve
+    """
+    async def _get_campaign_logic() -> str:
+        client = get_client()
+        result = await client.get_campaign(campaign_id)
+
+        campaign = result.get("data", {})
+        body = campaign.get('body', 'No content')
+        lists_str = ", ".join(str(lst.get("id")) for lst in campaign.get("lists", []))
+
+        return f"""Campaign ID: {campaign.get('id')}
+Name: {campaign.get('name')}
+Subject: {campaign.get('subject')}
+Status: {campaign.get('status')}
+Template ID: {campaign.get('template_id')}
+Lists: [{lists_str}]
+Content Type: {campaign.get('content_type', 'richtext')}
+
+Body:
+{body}"""
+
+    return await safe_execute_async(_get_campaign_logic)  # type: ignore[no-any-return]
 
 
 @mcp.tool()
@@ -842,6 +873,62 @@ async def get_list_subscribers_resource(list_id: str) -> str:
 
 
 # Template Management Tools
+@mcp.tool()
+async def get_templates() -> str:
+    """
+    Get all email templates.
+
+    Returns a list of all templates with their IDs, names, types, and default status.
+    """
+    async def _get_templates_logic() -> str:
+        client = get_client()
+        result = await client.get_templates()
+
+        data = result.get("data", {})
+        templates = data.get("results", []) if isinstance(data, dict) else data
+
+        if not templates:
+            return "No templates found."
+
+        template_items = []
+        for t in templates:
+            default_marker = " (DEFAULT)" if t.get('is_default', False) else ""
+            template_items.append(
+                f"- ID: {t.get('id')} | {t.get('name')} | "
+                f"Type: {t.get('type', 'campaign')}{default_marker}"
+            )
+
+        return f"Found {len(templates)} templates:\n" + "\n".join(template_items)
+
+    return await safe_execute_async(_get_templates_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def get_template(template_id: int) -> str:
+    """
+    Get a specific template by ID including its full body content.
+
+    Args:
+        template_id: ID of the template to retrieve
+    """
+    async def _get_template_logic() -> str:
+        client = get_client()
+        result = await client.get_template(template_id)
+
+        template = result.get("data", {})
+        body = template.get('body', 'No content')
+
+        return f"""Template ID: {template.get('id')}
+Name: {template.get('name')}
+Type: {template.get('type', 'campaign')}
+Default: {template.get('is_default', False)}
+
+Body:
+{body}"""
+
+    return await safe_execute_async(_get_template_logic)  # type: ignore[no-any-return]
+
+
 @mcp.tool()
 async def create_template(
     name: str,

--- a/src/listmonk_mcp/server.py
+++ b/src/listmonk_mcp/server.py
@@ -305,6 +305,36 @@ async def list_subscribers() -> str:
 
 # List Management Tools
 @mcp.tool()
+async def get_mailing_lists() -> str:
+    """
+    Get all mailing lists.
+
+    Returns a list of all mailing lists with their IDs, names, subscriber counts, and types.
+    """
+    async def _get_lists_logic() -> str:
+        client = get_client()
+        result = await client.get_lists()
+
+        data = result.get("data", {})
+        lists = data.get("results", []) if isinstance(data, dict) else data
+
+        if not lists:
+            return "No mailing lists found."
+
+        list_items = []
+        for lst in lists:
+            list_items.append(
+                f"- ID: {lst.get('id')} | {lst.get('name')} | "
+                f"Subscribers: {lst.get('subscriber_count', 0)} | "
+                f"Type: {lst.get('type', 'unknown')}"
+            )
+
+        return f"Found {len(lists)} mailing lists:\n" + "\n".join(list_items)
+
+    return await safe_execute_async(_get_lists_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
 async def create_mailing_list(
     name: str,
     type: str = "public",
@@ -414,14 +444,54 @@ async def get_list_subscribers_tool(
             per_page=per_page
         )
 
-        subscribers = result.get("data", [])
-        total = result.get("total", 0)
+        data = result.get("data", {})
+        subscribers = data.get("results", []) if isinstance(data, dict) else data
+        total = data.get("total", 0) if isinstance(data, dict) else len(subscribers)
         return f"Successfully retrieved {len(subscribers)} subscribers for list {list_id} (Total: {total}, Page: {page})"
 
     return await safe_execute_async(_get_list_subscribers_logic)  # type: ignore[no-any-return]
 
 
 # Campaign Management Tools
+@mcp.tool()
+async def get_campaigns(
+    status: str | None = None,
+    page: int = 1,
+    per_page: int = 20
+) -> str:
+    """
+    Get all campaigns with optional status filter.
+
+    Args:
+        status: Filter by status (draft, running, paused, finished, cancelled)
+        page: Page number for pagination
+        per_page: Number of campaigns per page
+    """
+    async def _get_campaigns_logic() -> str:
+        client = get_client()
+        result = await client.get_campaigns(page=page, per_page=per_page, status=status)
+
+        data = result.get("data", {})
+        campaigns = data.get("results", []) if isinstance(data, dict) else data
+        total = data.get("total", 0) if isinstance(data, dict) else len(campaigns)
+
+        if not campaigns:
+            return "No campaigns found."
+
+        campaign_items = []
+        for c in campaigns:
+            lists_str = ", ".join(str(lst.get("id")) for lst in c.get("lists", []))
+            campaign_items.append(
+                f"- ID: {c.get('id')} | {c.get('name')} | "
+                f"Status: {c.get('status', 'unknown')} | "
+                f"Lists: [{lists_str}]"
+            )
+
+        return f"Found {total} campaigns (showing {len(campaigns)}):\n" + "\n".join(campaign_items)
+
+    return await safe_execute_async(_get_campaigns_logic)  # type: ignore[no-any-return]
+
+
 @mcp.tool()
 async def create_campaign(
     name: str,

--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,7 @@ wheels = [
 
 [[package]]
 name = "listmonk-mcp"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Fix `get_list_subscribers` to use correct API endpoint
- Fix `update_campaign` to preserve existing lists when not provided
- Add `get_mailing_lists` and `get_campaigns` tools

## Fixes
- Fixes #1 - get_list_subscribers uses wrong API endpoint
- Fixes #2 - update_campaign fails when lists parameter is not provided
- Fixes #3 - Add get_mailing_lists and get_campaigns tools

## Changes

### `client.py`
1. **`get_list_subscribers`**: Changed from non-existent `/api/lists/{id}/subscribers` to correct `/api/subscribers?list_id={id}`
2. **`update_campaign`**: Now fetches current campaign's lists if `lists` parameter is not provided, preventing "Invalid List IDs" error

### `server.py`
1. **`get_mailing_lists` tool**: New tool to list all mailing lists with IDs, names, subscriber counts, and types
2. **`get_campaigns` tool**: New tool to list all campaigns with optional status filter
3. **`get_list_subscribers_tool`**: Fixed response parsing for nested `data.results` structure

## Testing
All fixes have been tested against a live Listmonk instance (v6.0.0).