### PR TITLE
feat: media management, discovery tools, campaign editing, and API fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "listmonk-mcp"
-version = "0.0.2"
+version = "0.0.3"
 description = "MCP server for Listmonk newsletter management"
 authors = [
     { name = "Rohan Verma", email = "hello@rohanverma.net" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "listmonk-mcp"
-version = "0.0.3"
+version = "0.0.12"
 description = "MCP server for Listmonk newsletter management"
 authors = [
     { name = "Rohan Verma", email = "hello@rohanverma.net" }

--- a/src/listmonk_mcp/client.py
+++ b/src/listmonk_mcp/client.py
@@ -270,8 +270,8 @@ class ListmonkClient:
 
     async def get_list_subscribers(self, list_id: int, page: int = 1, per_page: int = 20) -> dict[str, Any]:
         """Get subscribers for a specific list."""
-        params = {"page": page, "per_page": per_page}
-        return await self._request("GET", f"/api/lists/{list_id}/subscribers", params=params)
+        params = {"page": page, "per_page": per_page, "list_id": list_id}
+        return await self._request("GET", "/api/subscribers", params=params)
 
     # Campaign Operations
     async def get_campaigns(
@@ -328,14 +328,22 @@ class ListmonkClient:
         body: str | None = None,
         tags: list[str] | None = None
     ) -> dict[str, Any]:
-        """Update an existing campaign."""
-        data: dict[str, Any] = {}
+        """Update an existing campaign.
+
+        If lists is not provided, fetches the current campaign's lists to preserve them.
+        """
+        # If lists not provided, fetch current campaign to get existing lists
+        if lists is None:
+            current = await self.get_campaign(campaign_id)
+            campaign_data = current.get("data", {})
+            current_lists = campaign_data.get("lists", [])
+            lists = [lst.get("id") for lst in current_lists if lst.get("id")]
+
+        data: dict[str, Any] = {"lists": lists}
         if name is not None:
             data["name"] = name
         if subject is not None:
             data["subject"] = subject
-        if lists is not None:
-            data["lists"] = lists
         if body is not None:
             data["body"] = body
         if tags is not None:

--- a/src/listmonk_mcp/client.py
+++ b/src/listmonk_mcp/client.py
@@ -437,6 +437,91 @@ class ListmonkClient:
         }
         return await self._request("POST", "/api/tx", json_data=payload)
 
+    # Media Operations
+    async def get_media(self) -> dict[str, Any]:
+        """Get all media files."""
+        return await self._request("GET", "/api/media")
+
+    async def upload_media(self, file_path: str, title: str | None = None) -> dict[str, Any]:
+        """Upload a media file.
+
+        Args:
+            file_path: Absolute path to the file to upload
+            title: Optional title for the media file (defaults to filename)
+
+        Returns:
+            Dict containing the uploaded media data including URL
+        """
+        import os
+        from pathlib import Path
+
+        client = self._get_client()
+        url = self._build_url("/api/media")
+
+        file_path_obj = Path(file_path)
+        if not file_path_obj.exists():
+            raise ListmonkAPIError(f"File not found: {file_path}")
+
+        # Determine content type from file extension
+        content_types = {
+            '.jpg': 'image/jpeg',
+            '.jpeg': 'image/jpeg',
+            '.png': 'image/png',
+            '.gif': 'image/gif',
+            '.webp': 'image/webp',
+            '.svg': 'image/svg+xml',
+        }
+        ext = file_path_obj.suffix.lower()
+        content_type = content_types.get(ext, 'application/octet-stream')
+
+        # Use filename as title if not provided
+        if title is None:
+            title = file_path_obj.name
+
+        # Read file content
+        with open(file_path, 'rb') as f:
+            file_content = f.read()
+
+        # Prepare multipart form data
+        files = {
+            'file': (file_path_obj.name, file_content, content_type)
+        }
+        data = {}
+        if title:
+            data['title'] = title
+
+        try:
+            # Remove Content-Type header for multipart, httpx will set it automatically
+            headers = {
+                "Authorization": f"token {self.config.username}:{self.config.password}",
+                "User-Agent": "Listmonk-MCP-Server/0.1.0",
+                "Accept": "application/json",
+            }
+
+            response = await client.post(url, files=files, data=data, headers=headers)
+            return await self._handle_response(response)
+
+        except httpx.RequestError as e:
+            raise ListmonkAPIError(f"Media upload failed: {str(e)}") from e
+
+    async def update_media(self, media_id: int, title: str) -> dict[str, Any]:
+        """Update media file metadata (rename).
+
+        Args:
+            media_id: ID of the media file
+            title: New title for the media file
+        """
+        data = {"title": title}
+        return await self._request("PUT", f"/api/media/{media_id}", json_data=data)
+
+    async def delete_media(self, media_id: int) -> dict[str, Any]:
+        """Delete a media file.
+
+        Args:
+            media_id: ID of the media file to delete
+        """
+        return await self._request("DELETE", f"/api/media/{media_id}")
+
 
 async def create_client(config: Config) -> ListmonkClient:
     """Create and connect a Listmonk client."""

--- a/src/listmonk_mcp/client.py
+++ b/src/listmonk_mcp/client.py
@@ -396,14 +396,23 @@ class ListmonkClient:
         body: str | None = None,
         is_default: bool | None = None
     ) -> dict[str, Any]:
-        """Update an existing template."""
-        data: dict[str, Any] = {}
-        if name is not None:
-            data["name"] = name
-        if body is not None:
-            data["body"] = body
-        if is_default is not None:
-            data["is_default"] = is_default
+        """Update an existing template.
+
+        Fetches the current template first and merges changes, as Listmonk
+        requires all fields in PUT requests.
+        """
+        # Fetch current template to get all existing values
+        current = await self.get_template(template_id)
+        template_data = current.get("data", {})
+
+        # Build update data with current values as defaults
+        # IMPORTANT: type must be included, otherwise Listmonk validates as transactional template
+        data: dict[str, Any] = {
+            "name": name if name is not None else template_data.get("name", ""),
+            "type": template_data.get("type", "campaign"),
+            "body": body if body is not None else template_data.get("body", ""),
+            "is_default": is_default if is_default is not None else template_data.get("is_default", False),
+        }
 
         return await self._request("PUT", f"/api/templates/{template_id}", json_data=data)
 

--- a/src/listmonk_mcp/client.py
+++ b/src/listmonk_mcp/client.py
@@ -42,7 +42,7 @@ class ListmonkClient:
         auth_token = f"{self.config.username}:{self.config.password}"
 
         self._client = AsyncClient(
-            timeout=httpx.Timeout(self.config.timeout),
+            timeout=self.config.timeout,
             limits=httpx.Limits(max_keepalive_connections=5, max_connections=10),
             headers={
                 "User-Agent": "Listmonk-MCP-Server/0.1.0",
@@ -491,14 +491,20 @@ class ListmonkClient:
             data['title'] = title
 
         try:
-            # Remove Content-Type header for multipart, httpx will set it automatically
-            headers = {
-                "Authorization": f"token {self.config.username}:{self.config.password}",
-                "User-Agent": "Listmonk-MCP-Server/0.1.0",
-                "Accept": "application/json",
-            }
+            # Create a new client without Content-Type header for multipart upload
+            # The client will automatically set multipart/form-data with boundary
+            upload_client = AsyncClient(
+                timeout=self.config.timeout,
+                headers={
+                    "Authorization": f"token {self.config.username}:{self.config.password}",
+                    "User-Agent": "Listmonk-MCP-Server/0.1.0",
+                    "Accept": "application/json",
+                    # No Content-Type - will be set automatically by httpx for multipart
+                }
+            )
 
-            response = await client.post(url, files=files, data=data, headers=headers)
+            response = await upload_client.post(url, files=files, data=data)
+            await upload_client.aclose()
             return await self._handle_response(response)
 
         except httpx.RequestError as e:

--- a/src/listmonk_mcp/exceptions.py
+++ b/src/listmonk_mcp/exceptions.py
@@ -358,4 +358,6 @@ async def safe_execute_async(func: Any, *args: Any, **kwargs: Any) -> Any:
         error_details = convert_listmonk_api_error(e).to_dict()
         return f"Error: {error_details['error_type']} - {error_details['message']}"
     except Exception as e:
-        return f"Unexpected error: {str(e)}"
+        import traceback
+        tb = traceback.format_exc()
+        return f"Unexpected error: {str(e)}\n\nTraceback:\n{tb}"

--- a/src/listmonk_mcp/server.py
+++ b/src/listmonk_mcp/server.py
@@ -1149,23 +1149,44 @@ async def get_media_list() -> str:
         client = get_client()
         result = await client.get_media()
 
+        # Debug: Check what we actually got
+        if not isinstance(result, dict):
+            return f"Error: Unexpected response type: {type(result)}. Response: {result}"
+
         data = result.get("data", [])
 
-        if not data:
+        # Handle both list and dict formats (Listmonk can return either)
+        if isinstance(data, dict):
+            # If it's a dict, it might be empty or have numbered keys
+            if not data:
+                return "No media files found."
+            # Convert dict values to list
+            media_list = list(data.values()) if data else []
+        else:
+            # It's already a list
+            media_list = data
+
+        # Flatten if the first element is itself a list (nested structure)
+        if media_list and isinstance(media_list[0], list):
+            media_list = media_list[0]
+
+        if not media_list:
             return "No media files found."
 
         media_items = []
-        for media in data:
+        for media in media_list:
             created = media.get('created_at', 'Unknown')[:10]  # Just the date part
+            size_bytes = media.get('meta', {}).get('size', 0) if isinstance(media.get('meta'), dict) else 0
+            size_kb = size_bytes / 1024 if size_bytes > 0 else 0
             media_items.append(
                 f"- ID: {media.get('id')} | {media.get('filename')} | "
-                f"Title: {media.get('title', 'No title')} | "
-                f"Size: {media.get('size', 0)} bytes | "
+                f"Title: {media.get('title', media.get('filename', 'No title'))} | "
+                f"Size: {size_kb:.1f} KB | "
                 f"Created: {created}\n"
-                f"  URL: {media.get('uri', 'No URL')}"
+                f"  URL: {media.get('url', 'No URL')}"
             )
 
-        return f"Found {len(data)} media files:\n" + "\n".join(media_items)
+        return f"Found {len(media_list)} media files:\n" + "\n".join(media_items)
 
     return await safe_execute_async(_get_media_logic)  # type: ignore[no-any-return]
 
@@ -1191,10 +1212,10 @@ async def upload_media_file(
 
         media_data = result.get("data", {})
         media_id = media_data.get("id", "unknown")
-        uri = media_data.get("uri", "No URL")
+        url = media_data.get("url", "No URL")
         filename = media_data.get("filename", "unknown")
 
-        return f"Successfully uploaded '{filename}' (ID: {media_id})\nURL: {uri}"
+        return f"Successfully uploaded '{filename}' (ID: {media_id})\nURL: {url}"
 
     return await safe_execute_async(_upload_media_logic)  # type: ignore[no-any-return]
 
@@ -1250,34 +1271,237 @@ async def list_media_files() -> str:
 
         data = result.get("data", [])
 
-        if not data:
+        # Handle both list and dict formats
+        if isinstance(data, dict):
+            if not data:
+                return "# Media Files\n\nNo media files found."
+            media_list = list(data.values())
+        else:
+            media_list = data
+
+        # Flatten if the first element is itself a list (nested structure)
+        if media_list and isinstance(media_list[0], list):
+            media_list = media_list[0]
+
+        if not media_list:
             return "# Media Files\n\nNo media files found."
 
-        media_list = []
-        for media in data:
-            size_kb = media.get('size', 0) / 1024
+        media_items = []
+        for media in media_list:
+            size_bytes = media.get('meta', {}).get('size', 0) if isinstance(media.get('meta'), dict) else 0
+            size_kb = size_bytes / 1024 if size_bytes > 0 else 0
             created = media.get('created_at', 'Unknown')
-            media_list.append(
+            media_items.append(
                 f"- **{media.get('filename')}** (ID: {media.get('id')})\n"
-                f"  - Title: {media.get('title', 'No title')}\n"
+                f"  - Title: {media.get('title', media.get('filename', 'No title'))}\n"
                 f"  - Size: {size_kb:.1f} KB\n"
                 f"  - Created: {created}\n"
-                f"  - URL: {media.get('uri', 'No URL')}"
+                f"  - URL: {media.get('url', 'No URL')}"
             )
 
-        media_items = "\n\n".join(media_list)
+        media_items_text = "\n\n".join(media_items)
 
         return f"""# Media Files
 
-**Total Files:** {len(data)}
+**Total Files:** {len(media_list)}
 
-{media_items}
+{media_items_text}
 
 *Use upload_media_file to add new files, rename_media to update titles, or delete_media_file to remove files.*
 """
 
     except ListmonkAPIError as e:
         return f"Error retrieving media files: {str(e)}"
+
+
+# Campaign Body Editing Tools
+
+@mcp.tool()
+async def replace_in_campaign_body(
+    campaign_id: int,
+    search: str,
+    replace: str
+) -> str:
+    """
+    Search and replace text in a campaign body (simple string matching).
+
+    This is much more token-efficient than updating the entire campaign body.
+
+    Args:
+        campaign_id: ID of the campaign to edit
+        search: Text to search for (exact string match)
+        replace: Text to replace it with
+
+    Returns:
+        Success message with number of replacements made
+
+    Example:
+        replace_in_campaign_body(
+            campaign_id=11,
+            search="</p>",
+            replace="</p>\n<img src='https://...' style='...'>"
+        )
+    """
+    async def _replace_logic() -> str:
+        client = get_client()
+
+        # Fetch current campaign
+        result = await client.get_campaign(campaign_id)
+        campaign = result.get("data", {})
+
+        if not campaign:
+            return f"Campaign {campaign_id} not found"
+
+        current_body = campaign.get("body", "")
+
+        # Perform replacement
+        new_body = current_body.replace(search, replace)
+        count = current_body.count(search)
+
+        if count == 0:
+            return f"Search text not found in campaign {campaign_id}"
+
+        # Update campaign with new body
+        await client.update_campaign(
+            campaign_id=campaign_id,
+            name=campaign.get("name"),
+            subject=campaign.get("subject"),
+            lists=[lst["id"] for lst in campaign.get("lists", [])],
+            body=new_body
+        )
+
+        return f"Successfully replaced {count} occurrence(s) in campaign {campaign_id}"
+
+    return await safe_execute_async(_replace_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def regex_replace_in_campaign_body(
+    campaign_id: int,
+    pattern: str,
+    replace: str
+) -> str:
+    """
+    Search and replace in campaign body using regex patterns.
+
+    More powerful than simple replace - supports capturing groups and complex patterns.
+
+    Args:
+        campaign_id: ID of the campaign to edit
+        pattern: Regex pattern to search for
+        replace: Replacement string (can use \\1, \\2 for capture groups)
+
+    Returns:
+        Success message with number of replacements made
+
+    Example:
+        regex_replace_in_campaign_body(
+            campaign_id=11,
+            pattern=r"(Bondeni.*?</p>)",
+            replace=r"\\1\n<img src='https://...'>"
+        )
+    """
+    async def _regex_replace_logic() -> str:
+        import re
+
+        client = get_client()
+
+        # Fetch current campaign
+        result = await client.get_campaign(campaign_id)
+        campaign = result.get("data", {})
+
+        if not campaign:
+            return f"Campaign {campaign_id} not found"
+
+        current_body = campaign.get("body", "")
+
+        # Perform regex replacement
+        new_body, count = re.subn(pattern, replace, current_body)
+
+        if count == 0:
+            return f"Pattern not found in campaign {campaign_id}"
+
+        # Update campaign with new body
+        await client.update_campaign(
+            campaign_id=campaign_id,
+            name=campaign.get("name"),
+            subject=campaign.get("subject"),
+            lists=[lst["id"] for lst in campaign.get("lists", [])],
+            body=new_body
+        )
+
+        return f"Successfully replaced {count} match(es) in campaign {campaign_id}"
+
+    return await safe_execute_async(_regex_replace_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def batch_replace_in_campaign_body(
+    campaign_id: int,
+    replacements: list[dict[str, str]]
+) -> str:
+    """
+    Perform multiple search-and-replace operations in one go.
+
+    Even more efficient - fetches campaign once, does all replacements, updates once.
+
+    Args:
+        campaign_id: ID of the campaign to edit
+        replacements: List of dicts with 'search' and 'replace' keys
+
+    Returns:
+        Success message with total replacements made
+
+    Example:
+        batch_replace_in_campaign_body(
+            campaign_id=11,
+            replacements=[
+                {"search": "Text A", "replace": "Text B"},
+                {"search": "Text C", "replace": "Text D"}
+            ]
+        )
+    """
+    async def _batch_replace_logic() -> str:
+        client = get_client()
+
+        # Fetch current campaign
+        result = await client.get_campaign(campaign_id)
+        campaign = result.get("data", {})
+
+        if not campaign:
+            return f"Campaign {campaign_id} not found"
+
+        current_body = campaign.get("body", "")
+        new_body = current_body
+        total_count = 0
+
+        # Perform all replacements
+        for replacement in replacements:
+            search = replacement.get("search", "")
+            replace = replacement.get("replace", "")
+
+            if not search:
+                continue
+
+            count = new_body.count(search)
+            new_body = new_body.replace(search, replace)
+            total_count += count
+
+        if total_count == 0:
+            return f"No search texts found in campaign {campaign_id}"
+
+        # Update campaign with new body
+        await client.update_campaign(
+            campaign_id=campaign_id,
+            name=campaign.get("name"),
+            subject=campaign.get("subject"),
+            lists=[lst["id"] for lst in campaign.get("lists", [])],
+            body=new_body
+        )
+
+        return f"Successfully completed {len(replacements)} replacement operation(s) with {total_count} total change(s) in campaign {campaign_id}"
+
+    return await safe_execute_async(_batch_replace_logic)  # type: ignore[no-any-return]
 
 
 # CLI application

--- a/src/listmonk_mcp/server.py
+++ b/src/listmonk_mcp/server.py
@@ -1137,6 +1137,149 @@ async def get_template_preview(template_id: str) -> str:
         return f"Error retrieving template content {template_id}: {str(e)}"
 
 
+# Media Management Tools
+@mcp.tool()
+async def get_media_list() -> str:
+    """
+    Get all media files from Listmonk.
+
+    Returns a list of all uploaded media with their IDs, filenames, URLs, and metadata.
+    """
+    async def _get_media_logic() -> str:
+        client = get_client()
+        result = await client.get_media()
+
+        data = result.get("data", [])
+
+        if not data:
+            return "No media files found."
+
+        media_items = []
+        for media in data:
+            created = media.get('created_at', 'Unknown')[:10]  # Just the date part
+            media_items.append(
+                f"- ID: {media.get('id')} | {media.get('filename')} | "
+                f"Title: {media.get('title', 'No title')} | "
+                f"Size: {media.get('size', 0)} bytes | "
+                f"Created: {created}\n"
+                f"  URL: {media.get('uri', 'No URL')}"
+            )
+
+        return f"Found {len(data)} media files:\n" + "\n".join(media_items)
+
+    return await safe_execute_async(_get_media_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def upload_media_file(
+    file_path: str,
+    title: str | None = None
+) -> str:
+    """
+    Upload a media file to Listmonk.
+
+    Args:
+        file_path: Absolute path to the image file to upload
+        title: Optional title/description for the media (defaults to filename)
+
+    Returns:
+        Success message with the uploaded file's URL
+    """
+    async def _upload_media_logic() -> str:
+        client = get_client()
+        result = await client.upload_media(file_path, title)
+
+        media_data = result.get("data", {})
+        media_id = media_data.get("id", "unknown")
+        uri = media_data.get("uri", "No URL")
+        filename = media_data.get("filename", "unknown")
+
+        return f"Successfully uploaded '{filename}' (ID: {media_id})\nURL: {uri}"
+
+    return await safe_execute_async(_upload_media_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def rename_media(media_id: int, new_title: str) -> str:
+    """
+    Rename/update the title of a media file.
+
+    Args:
+        media_id: ID of the media file to rename
+        new_title: New title/description for the media file
+
+    Returns:
+        Success message
+    """
+    async def _rename_media_logic() -> str:
+        client = get_client()
+        await client.update_media(media_id, new_title)
+
+        return f"Successfully renamed media {media_id} to '{new_title}'"
+
+    return await safe_execute_async(_rename_media_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def delete_media_file(media_id: int) -> str:
+    """
+    Delete a media file from Listmonk.
+
+    Args:
+        media_id: ID of the media file to delete
+
+    Returns:
+        Success message
+    """
+    async def _delete_media_logic() -> str:
+        client = get_client()
+        await client.delete_media(media_id)
+
+        return f"Successfully deleted media {media_id}"
+
+    return await safe_execute_async(_delete_media_logic)  # type: ignore[no-any-return]
+
+
+# Media Resources
+@mcp.resource("listmonk://media")
+async def list_media_files() -> str:
+    """List all media files with details."""
+    try:
+        client = get_client()
+        result = await client.get_media()
+
+        data = result.get("data", [])
+
+        if not data:
+            return "# Media Files\n\nNo media files found."
+
+        media_list = []
+        for media in data:
+            size_kb = media.get('size', 0) / 1024
+            created = media.get('created_at', 'Unknown')
+            media_list.append(
+                f"- **{media.get('filename')}** (ID: {media.get('id')})\n"
+                f"  - Title: {media.get('title', 'No title')}\n"
+                f"  - Size: {size_kb:.1f} KB\n"
+                f"  - Created: {created}\n"
+                f"  - URL: {media.get('uri', 'No URL')}"
+            )
+
+        media_items = "\n\n".join(media_list)
+
+        return f"""# Media Files
+
+**Total Files:** {len(data)}
+
+{media_items}
+
+*Use upload_media_file to add new files, rename_media to update titles, or delete_media_file to remove files.*
+"""
+
+    except ListmonkAPIError as e:
+        return f"Error retrieving media files: {str(e)}"
+
+
 # CLI application
 cli_app = typer.Typer(
     name="listmonk-mcp",

--- a/src/listmonk_mcp/server.py
+++ b/src/listmonk_mcp/server.py
@@ -309,7 +309,7 @@ async def get_mailing_lists() -> str:
     """
     Get all mailing lists.
 
-    Returns a list of all mailing lists with their IDs, names, subscriber counts, and types.
+    Returns a list of all mailing lists with their IDs, UUIDs, names, subscriber counts, and types.
     """
     async def _get_lists_logic() -> str:
         client = get_client()
@@ -325,6 +325,7 @@ async def get_mailing_lists() -> str:
         for lst in lists:
             list_items.append(
                 f"- ID: {lst.get('id')} | {lst.get('name')} | "
+                f"UUID: {lst.get('uuid')} | "
                 f"Subscribers: {lst.get('subscriber_count', 0)} | "
                 f"Type: {lst.get('type', 'unknown')}"
             )
@@ -490,6 +491,36 @@ async def get_campaigns(
         return f"Found {total} campaigns (showing {len(campaigns)}):\n" + "\n".join(campaign_items)
 
     return await safe_execute_async(_get_campaigns_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def get_campaign(campaign_id: int) -> str:
+    """
+    Get a specific campaign by ID including its full body content.
+
+    Args:
+        campaign_id: ID of the campaign to retrieve
+    """
+    async def _get_campaign_logic() -> str:
+        client = get_client()
+        result = await client.get_campaign(campaign_id)
+
+        campaign = result.get("data", {})
+        body = campaign.get('body', 'No content')
+        lists_str = ", ".join(str(lst.get("id")) for lst in campaign.get("lists", []))
+
+        return f"""Campaign ID: {campaign.get('id')}
+Name: {campaign.get('name')}
+Subject: {campaign.get('subject')}
+Status: {campaign.get('status')}
+Template ID: {campaign.get('template_id')}
+Lists: [{lists_str}]
+Content Type: {campaign.get('content_type', 'richtext')}
+
+Body:
+{body}"""
+
+    return await safe_execute_async(_get_campaign_logic)  # type: ignore[no-any-return]
 
 
 @mcp.tool()
@@ -842,6 +873,62 @@ async def get_list_subscribers_resource(list_id: str) -> str:
 
 
 # Template Management Tools
+@mcp.tool()
+async def get_templates() -> str:
+    """
+    Get all email templates.
+
+    Returns a list of all templates with their IDs, names, types, and default status.
+    """
+    async def _get_templates_logic() -> str:
+        client = get_client()
+        result = await client.get_templates()
+
+        data = result.get("data", {})
+        templates = data.get("results", []) if isinstance(data, dict) else data
+
+        if not templates:
+            return "No templates found."
+
+        template_items = []
+        for t in templates:
+            default_marker = " (DEFAULT)" if t.get('is_default', False) else ""
+            template_items.append(
+                f"- ID: {t.get('id')} | {t.get('name')} | "
+                f"Type: {t.get('type', 'campaign')}{default_marker}"
+            )
+
+        return f"Found {len(templates)} templates:\n" + "\n".join(template_items)
+
+    return await safe_execute_async(_get_templates_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def get_template(template_id: int) -> str:
+    """
+    Get a specific template by ID including its full body content.
+
+    Args:
+        template_id: ID of the template to retrieve
+    """
+    async def _get_template_logic() -> str:
+        client = get_client()
+        result = await client.get_template(template_id)
+
+        template = result.get("data", {})
+        body = template.get('body', 'No content')
+
+        return f"""Template ID: {template.get('id')}
+Name: {template.get('name')}
+Type: {template.get('type', 'campaign')}
+Default: {template.get('is_default', False)}
+
+Body:
+{body}"""
+
+    return await safe_execute_async(_get_template_logic)  # type: ignore[no-any-return]
+
+
 @mcp.tool()
 async def create_template(
     name: str,

--- a/src/listmonk_mcp/server.py
+++ b/src/listmonk_mcp/server.py
@@ -305,6 +305,36 @@ async def list_subscribers() -> str:
 
 # List Management Tools
 @mcp.tool()
+async def get_mailing_lists() -> str:
+    """
+    Get all mailing lists.
+
+    Returns a list of all mailing lists with their IDs, names, subscriber counts, and types.
+    """
+    async def _get_lists_logic() -> str:
+        client = get_client()
+        result = await client.get_lists()
+
+        data = result.get("data", {})
+        lists = data.get("results", []) if isinstance(data, dict) else data
+
+        if not lists:
+            return "No mailing lists found."
+
+        list_items = []
+        for lst in lists:
+            list_items.append(
+                f"- ID: {lst.get('id')} | {lst.get('name')} | "
+                f"Subscribers: {lst.get('subscriber_count', 0)} | "
+                f"Type: {lst.get('type', 'unknown')}"
+            )
+
+        return f"Found {len(lists)} mailing lists:\n" + "\n".join(list_items)
+
+    return await safe_execute_async(_get_lists_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
 async def create_mailing_list(
     name: str,
     type: str = "public",
@@ -414,14 +444,54 @@ async def get_list_subscribers_tool(
             per_page=per_page
         )
 
-        subscribers = result.get("data", [])
-        total = result.get("total", 0)
+        data = result.get("data", {})
+        subscribers = data.get("results", []) if isinstance(data, dict) else data
+        total = data.get("total", 0) if isinstance(data, dict) else len(subscribers)
         return f"Successfully retrieved {len(subscribers)} subscribers for list {list_id} (Total: {total}, Page: {page})"
 
     return await safe_execute_async(_get_list_subscribers_logic)  # type: ignore[no-any-return]
 
 
 # Campaign Management Tools
+@mcp.tool()
+async def get_campaigns(
+    status: str | None = None,
+    page: int = 1,
+    per_page: int = 20
+) -> str:
+    """
+    Get all campaigns with optional status filter.
+
+    Args:
+        status: Filter by status (draft, running, paused, finished, cancelled)
+        page: Page number for pagination
+        per_page: Number of campaigns per page
+    """
+    async def _get_campaigns_logic() -> str:
+        client = get_client()
+        result = await client.get_campaigns(page=page, per_page=per_page, status=status)
+
+        data = result.get("data", {})
+        campaigns = data.get("results", []) if isinstance(data, dict) else data
+        total = data.get("total", 0) if isinstance(data, dict) else len(campaigns)
+
+        if not campaigns:
+            return "No campaigns found."
+
+        campaign_items = []
+        for c in campaigns:
+            lists_str = ", ".join(str(lst.get("id")) for lst in c.get("lists", []))
+            campaign_items.append(
+                f"- ID: {c.get('id')} | {c.get('name')} | "
+                f"Status: {c.get('status', 'unknown')} | "
+                f"Lists: [{lists_str}]"
+            )
+
+        return f"Found {total} campaigns (showing {len(campaigns)}):\n" + "\n".join(campaign_items)
+
+    return await safe_execute_async(_get_campaigns_logic)  # type: ignore[no-any-return]
+
+
 @mcp.tool()
 async def create_campaign(
     name: str,

--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,7 @@ wheels = [
 
 [[package]]
 name = "listmonk-mcp"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,7 @@ wheels = [
 
 [[package]]
 name = "listmonk-mcp"
-version = "0.0.2"
+version = "0.0.12"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
This PR adds comprehensive media management and highly token-efficient campaign editing capabilities to listmonk-mcp.

## Motivation
While using listmonk-mcp for newsletter management, I found two major pain points:
1. **No media management** - Couldn't upload, list, or manage images via MCP
2. **Token inefficiency** - Updating a campaign body required regenerating 7000+ chars of HTML (~2500 output tokens) even for small changes like adding an image

These additions solve both problems and make listmonk-mcp significantly more practical for real-world usage.

## Features Added

### 📸 Media Management (Complete Implementation)
All media operations from the Listmonk API are now supported:

- **`upload_media_file(file_path, title)`** - Upload images with automatic content-type detection
- **`get_media_list()`** - List all uploaded media files with IDs, URLs, sizes
- **`rename_media(media_id, new_title)`** - Update media titles
- **`delete_media_file(media_id)`** - Remove media files
- **Resource `listmonk://media`** - Detailed media listings for context

### ⚡ Token-Efficient Campaign Editing (70-95% Token Savings)
Instead of regenerating entire campaign bodies, these tools fetch-modify-update:

- **`replace_in_campaign_body(campaign_id, search, replace)`** - Simple search & replace
  - Example: Add image after paragraph without rewriting entire newsletter
  - **~95% token savings** (100 tokens vs 2500)

- **`regex_replace_in_campaign_body(campaign_id, pattern, replace)`** - Regex with capture groups
  - Example: Insert content after specific text patterns
  - Supports \\1, \\2 for captures

- **`batch_replace_in_campaign_body(campaign_id, replacements)`** - Multiple operations at once
  - Example: Update multiple feature descriptions in one go
  - **~90% token savings** vs multiple full updates

### 🔧 Additional Improvements
- **UUID support in `get_mailing_lists`** - Essential for subscription form filtering (`?l=<uuid>`)
- **Fix httpx timeout bug** - Was using `Timeout(timeout=30)` instead of direct `timeout=30`
- **Fix multipart upload** - Content-Type header was blocking automatic multipart/form-data
- **Improved parameter types** - Changed `str = ""` to `str | None = None` for optional params

## Technical Details

### Media Upload Implementation
The tricky part was getting multipart/form-data to work:
- Main AsyncClient has `Content-Type: application/json` header
- This blocks httpx from auto-setting `multipart/form-data` with boundary
- Solution: Create separate AsyncClient instance for uploads without Content-Type header

### Token Efficiency Impact
Real-world example from my newsletter workflow:

**Before:**
```python
update_campaign(id=11, body="<7000 chars of HTML>", ...)  # 2500 output tokens
```

**After:**
```python
replace_in_campaign_body(id=11, 
    search="</p>", 
    replace="</p>\n<img src='...' style='...'>"
)  # 100 output tokens
```

For frequent small edits during newsletter composition, this is a **massive** improvement.

## Testing
All features tested against live Listmonk v6.0.0 instance:
- ✅ Media upload (PNG, JPG) with proper multipart encoding
- ✅ Media listing with correct nested data structure handling
- ✅ Campaign body replacements (simple, regex, batch)
- ✅ UUID filtering in subscription forms

## Versioning
Bumped to 0.0.12 to reflect significant feature additions.

## Notes
This PR is separate from #4 (bug fixes) as these are purely additive features rather than fixes.