### PR TITLE
Return subscriber data from get_list_subscribers_tool

### DIFF
--- a/src/listmonk_mcp/server.py
+++ b/src/listmonk_mcp/server.py
@@ -428,7 +428,7 @@ async def get_list_subscribers_tool(
     list_id: int,
     page: int = 1,
     per_page: int = 20
-) -> str:
+) -> dict[str, Any]:
     """
     Get subscribers for a specific mailing list.
 
@@ -437,7 +437,7 @@ async def get_list_subscribers_tool(
         page: Page number for pagination
         per_page: Number of subscribers per page
     """
-    async def _get_list_subscribers_logic() -> str:
+    async def _get_list_subscribers_logic() -> dict[str, Any]:
         client = get_client()
         result = await client.get_list_subscribers(
             list_id=list_id,
@@ -448,7 +448,15 @@ async def get_list_subscribers_tool(
         data = result.get("data", {})
         subscribers = data.get("results", []) if isinstance(data, dict) else data
         total = data.get("total", 0) if isinstance(data, dict) else len(subscribers)
-        return f"Successfully retrieved {len(subscribers)} subscribers for list {list_id} (Total: {total}, Page: {page})"
+        return {
+            "success": True,
+            "list_id": list_id,
+            "page": page,
+            "per_page": per_page,
+            "count": len(subscribers),
+            "total": total,
+            "subscribers": subscribers,
+        }
 
     return await safe_execute_async(_get_list_subscribers_logic)  # type: ignore[no-any-return]
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,65 @@
+from typing import Any
+
+import pytest
+
+from listmonk_mcp import server
+
+
+class FakeListmonkClient:
+    async def get_list_subscribers(
+        self,
+        list_id: int,
+        page: int = 1,
+        per_page: int = 20,
+    ) -> dict[str, Any]:
+        return {
+            "data": {
+                "results": [
+                    {
+                        "id": 1,
+                        "email": "ada@example.com",
+                        "name": "Ada Lovelace",
+                        "status": "enabled",
+                    },
+                    {
+                        "id": 2,
+                        "email": "grace@example.com",
+                        "name": "Grace Hopper",
+                        "status": "enabled",
+                    },
+                ],
+                "total": 2,
+            }
+        }
+
+
+@pytest.mark.asyncio
+async def test_get_list_subscribers_tool_returns_subscribers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(server, "get_client", lambda: FakeListmonkClient())
+
+    result = await server.get_list_subscribers_tool(list_id=7, page=2, per_page=10)
+
+    assert result == {
+        "success": True,
+        "list_id": 7,
+        "page": 2,
+        "per_page": 10,
+        "count": 2,
+        "total": 2,
+        "subscribers": [
+            {
+                "id": 1,
+                "email": "ada@example.com",
+                "name": "Ada Lovelace",
+                "status": "enabled",
+            },
+            {
+                "id": 2,
+                "email": "grace@example.com",
+                "name": "Grace Hopper",
+                "status": "enabled",
+            },
+        ],
+    }


### PR DESCRIPTION
Fixes #6.

`get_list_subscribers_tool` previously returned only a summary string, so MCP clients could see the subscriber count but not the actual subscribers.

This changes the tool to return a structured response containing pagination metadata and the `subscribers` list.

Also adds a regression test for the returned structure.