### PR TITLE
feat: comprehensive API coverage — 30 new tools across campaigns, subscribers, bounces, import, settings, maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This server will bridge the MCP protocol with Listmonk's REST API, providing a s
 ## Features
 
 - **Complete Listmonk API Coverage**: All major Listmonk operations supported
-- **18 MCP Tools**: Comprehensive subscriber, list, campaign, and template management
+- **70 MCP Tools**: Subscriber, list, campaign, template, media, bounce, import, settings, and maintenance management — full campaign lifecycle (test/send/pause/cancel/delete/archive/analytics), bounce handling, bulk operations, and admin endpoints
 - **MCP Resources**: Easy access to subscriber, list, campaign, and template data
 - **Async Operations**: Built with modern async/await patterns
 - **Type Safety**: Full Pydantic model validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "listmonk-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP server for Listmonk newsletter management"
 authors = [
     { name = "Rohan Verma", email = "hello@rohanverma.net" }

--- a/src/listmonk_mcp/client.py
+++ b/src/listmonk_mcp/client.py
@@ -604,8 +604,35 @@ class ListmonkClient:
         campaign_id: int,
         subscribers: list[str],
     ) -> dict[str, Any]:
-        """Send a test of the campaign to one or more subscriber emails."""
-        data = {"subscribers": subscribers}
+        """Send a test of the campaign to one or more subscriber emails.
+
+        Listmonk's test endpoint validates the full campaign payload
+        (name/subject/lists/body/messenger/content_type), so we fetch the
+        saved campaign and merge those fields into the test request — same
+        pattern as update_campaign.
+
+        Note: recipients must already exist as subscribers in listmonk;
+        the test handler looks them up by email and silently sends nothing
+        if no record matches.
+        """
+        current = await self.get_campaign(campaign_id)
+        camp = current.get("data", {})
+
+        data: dict[str, Any] = {
+            "name": camp.get("name", ""),
+            "subject": camp.get("subject", ""),
+            "lists": [lst.get("id") for lst in camp.get("lists", []) if lst.get("id")],
+            "from_email": camp.get("from_email", ""),
+            "body": camp.get("body", ""),
+            "altbody": camp.get("altbody") or "",
+            "content_type": camp.get("content_type", "richtext"),
+            "messenger": camp.get("messenger", "email"),
+            "type": camp.get("type", "regular"),
+            "tags": camp.get("tags", []) or [],
+            "template_id": camp.get("template_id", 0),
+            "headers": camp.get("headers", []) or [],
+            "subscribers": subscribers,
+        }
         return await self._request("POST", f"/api/campaigns/{campaign_id}/test", json_data=data)
 
     async def change_campaign_status(self, campaign_id: int, status: str) -> dict[str, Any]:

--- a/src/listmonk_mcp/client.py
+++ b/src/listmonk_mcp/client.py
@@ -76,7 +76,7 @@ class ListmonkClient:
         method: str,
         endpoint: str,
         params: dict[str, Any] | None = None,
-        json_data: dict[str, Any] | None = None,
+        json_data: Any = None,
         retry_count: int = 0
     ) -> dict[str, Any]:
         """Make HTTP request with retry logic and error handling."""
@@ -780,8 +780,15 @@ class ListmonkClient:
         return await self._request("PUT", "/api/settings", json_data=settings)
 
     async def update_setting(self, key: str, value: Any) -> dict[str, Any]:
-        """Update a single settings key (avoids the password-masking footgun)."""
-        return await self._request("PUT", f"/api/settings/{key}", json_data={"value": value})
+        """Update a single settings key (avoids the password-masking footgun).
+
+        Listmonk's per-key settings handler reads the request body as a raw
+        JSON value and writes it directly into the settings document — so
+        the body must be the value itself (e.g. a JSON string for a string
+        setting), NOT wrapped in {"value": ...}. Wrapping causes listmonk
+        to store the whole object and breaks the field.
+        """
+        return await self._request("PUT", f"/api/settings/{key}", json_data=value)
 
     async def test_smtp_settings(self, settings: dict[str, Any]) -> dict[str, Any]:
         """Send a test email through provided SMTP settings."""

--- a/src/listmonk_mcp/client.py
+++ b/src/listmonk_mcp/client.py
@@ -211,6 +211,241 @@ class ListmonkClient:
         data = {"status": status}
         return await self._request("PUT", f"/api/subscribers/{subscriber_id}", json_data=data)
 
+    async def patch_subscriber(
+        self,
+        subscriber_id: int,
+        action: str,
+        target_list_ids: list[int] | None = None,
+        status: str | None = None,
+    ) -> dict[str, Any]:
+        """Patch a subscriber's lists or status.
+
+        Args:
+            subscriber_id: Subscriber to patch.
+            action: One of "add", "remove", "unsubscribe" (lists),
+                or "blocklist" / "enable" (status).
+            target_list_ids: List IDs (for list-related actions).
+            status: New status (for status-related actions).
+        """
+        data: dict[str, Any] = {"action": action}
+        if target_list_ids is not None:
+            data["target_list_ids"] = target_list_ids
+        if status is not None:
+            data["status"] = status
+        return await self._request("PATCH", f"/api/subscribers/{subscriber_id}", json_data=data)
+
+    async def subscriber_send_optin(self, subscriber_id: int) -> dict[str, Any]:
+        """Trigger an opt-in confirmation email to a subscriber."""
+        return await self._request("POST", f"/api/subscribers/{subscriber_id}/optin")
+
+    async def blocklist_subscriber(self, subscriber_id: int) -> dict[str, Any]:
+        """Blocklist a single subscriber."""
+        return await self._request("PUT", f"/api/subscribers/{subscriber_id}/blocklist")
+
+    async def blocklist_subscribers(self, subscriber_ids: list[int]) -> dict[str, Any]:
+        """Blocklist multiple subscribers in one call."""
+        return await self._request(
+            "PUT",
+            "/api/subscribers/blocklist",
+            json_data={"ids": subscriber_ids},
+        )
+
+    async def manage_subscriber_lists(
+        self,
+        subscriber_ids: list[int],
+        target_list_ids: list[int],
+        action: str,
+        status: str | None = None,
+    ) -> dict[str, Any]:
+        """Bulk add / remove / unsubscribe subscribers from lists.
+
+        Args:
+            subscriber_ids: Subscriber IDs to update.
+            target_list_ids: Lists to operate on.
+            action: One of "add", "remove", "unsubscribe".
+            status: Optional subscription status (e.g. "confirmed", "unconfirmed").
+        """
+        data: dict[str, Any] = {
+            "ids": subscriber_ids,
+            "action": action,
+            "target_list_ids": target_list_ids,
+        }
+        if status is not None:
+            data["status"] = status
+        return await self._request("PUT", "/api/subscribers/lists", json_data=data)
+
+    async def get_subscriber_activity(self, subscriber_id: int) -> dict[str, Any]:
+        """Get a subscriber's activity log (opt-ins, bounces, list changes)."""
+        return await self._request("GET", f"/api/subscribers/{subscriber_id}/activity")
+
+    async def delete_subscribers(self, subscriber_ids: list[int]) -> dict[str, Any]:
+        """Delete multiple subscribers by ID."""
+        params = {"id": [str(sid) for sid in subscriber_ids]}
+        return await self._request("DELETE", "/api/subscribers", params=params)
+
+    async def delete_subscribers_by_query(
+        self,
+        query: str,
+        list_ids: list[int] | None = None,
+    ) -> dict[str, Any]:
+        """Delete subscribers matching an advanced SQL query expression."""
+        data: dict[str, Any] = {"query": query, "list_ids": list_ids or []}
+        return await self._request("POST", "/api/subscribers/query/delete", json_data=data)
+
+    async def blocklist_subscribers_by_query(
+        self,
+        query: str,
+        list_ids: list[int] | None = None,
+    ) -> dict[str, Any]:
+        """Blocklist subscribers matching an advanced SQL query expression."""
+        data: dict[str, Any] = {"query": query, "list_ids": list_ids or []}
+        return await self._request("PUT", "/api/subscribers/query/blocklist", json_data=data)
+
+    async def manage_subscriber_lists_by_query(
+        self,
+        query: str,
+        target_list_ids: list[int],
+        action: str,
+        list_ids: list[int] | None = None,
+        status: str | None = None,
+    ) -> dict[str, Any]:
+        """Bulk add/remove/unsubscribe subscribers matching a query."""
+        data: dict[str, Any] = {
+            "query": query,
+            "list_ids": list_ids or [],
+            "target_list_ids": target_list_ids,
+            "action": action,
+        }
+        if status is not None:
+            data["status"] = status
+        return await self._request("PUT", "/api/subscribers/query/lists", json_data=data)
+
+    async def get_subscriber_bounces(self, subscriber_id: int) -> dict[str, Any]:
+        """Get bounce records for a single subscriber."""
+        return await self._request("GET", f"/api/subscribers/{subscriber_id}/bounces")
+
+    async def delete_subscriber_bounces(self, subscriber_id: int) -> dict[str, Any]:
+        """Delete all bounce records for a single subscriber."""
+        return await self._request("DELETE", f"/api/subscribers/{subscriber_id}/bounces")
+
+    # Bounce Operations
+    async def get_bounces(
+        self,
+        page: int = 1,
+        per_page: int = 20,
+        campaign_id: int | None = None,
+        source: str | None = None,
+        order_by: str = "created_at",
+        order: str = "desc",
+    ) -> dict[str, Any]:
+        """Get bounce records with pagination and filtering."""
+        params: dict[str, Any] = {
+            "page": page,
+            "per_page": per_page,
+            "order_by": order_by,
+            "order": order,
+        }
+        if campaign_id is not None:
+            params["campaign_id"] = campaign_id
+        if source is not None:
+            params["source"] = source
+        return await self._request("GET", "/api/bounces", params=params)
+
+    async def get_bounce(self, bounce_id: int) -> dict[str, Any]:
+        """Get a single bounce record by ID."""
+        return await self._request("GET", f"/api/bounces/{bounce_id}")
+
+    async def delete_bounce(self, bounce_id: int) -> dict[str, Any]:
+        """Delete a single bounce record."""
+        return await self._request("DELETE", f"/api/bounces/{bounce_id}")
+
+    async def delete_bounces(self, bounce_ids: list[int] | None = None) -> dict[str, Any]:
+        """Delete bounce records. Pass None or empty list to delete ALL bounces."""
+        if bounce_ids:
+            params = {"id": [str(bid) for bid in bounce_ids]}
+            return await self._request("DELETE", "/api/bounces", params=params)
+        return await self._request("DELETE", "/api/bounces", params={"all": "true"})
+
+    async def blocklist_bounced_subscribers(
+        self, bounce_ids: list[int] | None = None
+    ) -> dict[str, Any]:
+        """Blocklist subscribers attached to specific bounces (or all if empty)."""
+        data: dict[str, Any] = {"all": not bool(bounce_ids), "ids": bounce_ids or []}
+        return await self._request("PUT", "/api/bounces/blocklist", json_data=data)
+
+    # Subscriber Import Operations
+    async def get_import_status(self) -> dict[str, Any]:
+        """Get the status of the current/last subscriber import."""
+        return await self._request("GET", "/api/import/subscribers")
+
+    async def get_import_logs(self) -> dict[str, Any]:
+        """Get logs from the current/last subscriber import."""
+        return await self._request("GET", "/api/import/subscribers/logs")
+
+    async def import_subscribers(
+        self,
+        file_path: str,
+        mode: str = "subscribe",
+        list_ids: list[int] | None = None,
+        delim: str = ",",
+        overwrite: bool = True,
+        subscription_status: str = "confirmed",
+    ) -> dict[str, Any]:
+        """Start a subscriber import from a CSV/zip file.
+
+        Args:
+            file_path: Local path to a .csv or .zip file.
+            mode: "subscribe" or "blocklist".
+            list_ids: Lists to subscribe imported users to.
+            delim: CSV delimiter (default ",").
+            overwrite: Whether to overwrite existing subscribers.
+            subscription_status: "confirmed" or "unconfirmed".
+        """
+        import json as _json
+        from pathlib import Path
+
+        url = self._build_url("/api/import/subscribers")
+        file_path_obj = Path(file_path)
+        if not file_path_obj.exists():
+            raise ListmonkAPIError(f"File not found: {file_path}")
+
+        ext = file_path_obj.suffix.lower()
+        content_type = "application/zip" if ext == ".zip" else "text/csv"
+
+        with open(file_path, "rb") as f:
+            file_content = f.read()
+
+        params = {
+            "mode": mode,
+            "subscription_status": subscription_status,
+            "delim": delim,
+            "lists": list_ids or [],
+            "overwrite": overwrite,
+        }
+
+        files = {"file": (file_path_obj.name, file_content, content_type)}
+        data = {"params": _json.dumps(params)}
+
+        upload_client = AsyncClient(
+            timeout=self.config.timeout,
+            headers={
+                "Authorization": f"token {self.config.username}:{self.config.password}",
+                "User-Agent": "Listmonk-MCP-Server/0.1.0",
+                "Accept": "application/json",
+            },
+        )
+        try:
+            response = await upload_client.post(url, files=files, data=data)
+            return await self._handle_response(response)
+        except httpx.RequestError as e:
+            raise ListmonkAPIError(f"Subscriber import failed: {str(e)}") from e
+        finally:
+            await upload_client.aclose()
+
+    async def stop_import(self) -> dict[str, Any]:
+        """Stop the currently running subscriber import."""
+        return await self._request("DELETE", "/api/import/subscribers")
+
     # List Operations
     async def get_lists(self) -> dict[str, Any]:
         """Get all mailing lists."""
@@ -364,6 +599,76 @@ class ListmonkClient:
         """Get campaign HTML preview."""
         return await self._request("GET", f"/api/campaigns/{campaign_id}/preview")
 
+    async def test_campaign(
+        self,
+        campaign_id: int,
+        subscribers: list[str],
+    ) -> dict[str, Any]:
+        """Send a test of the campaign to one or more subscriber emails."""
+        data = {"subscribers": subscribers}
+        return await self._request("POST", f"/api/campaigns/{campaign_id}/test", json_data=data)
+
+    async def change_campaign_status(self, campaign_id: int, status: str) -> dict[str, Any]:
+        """Change a campaign's status (draft, scheduled, running, paused, cancelled)."""
+        return await self._request(
+            "PUT",
+            f"/api/campaigns/{campaign_id}/status",
+            json_data={"status": status},
+        )
+
+    async def archive_campaign(
+        self,
+        campaign_id: int,
+        archive: bool,
+        archive_template_id: int | None = None,
+        archive_meta: dict[str, Any] | None = None,
+        archive_slug: str | None = None,
+    ) -> dict[str, Any]:
+        """Toggle a campaign's archive flag and optionally update archive metadata."""
+        data: dict[str, Any] = {"archive": archive}
+        if archive_template_id is not None:
+            data["archive_template_id"] = archive_template_id
+        if archive_meta is not None:
+            data["archive_meta"] = archive_meta
+        if archive_slug is not None:
+            data["archive_slug"] = archive_slug
+        return await self._request("PUT", f"/api/campaigns/{campaign_id}/archive", json_data=data)
+
+    async def delete_campaign(self, campaign_id: int) -> dict[str, Any]:
+        """Delete a single campaign."""
+        return await self._request("DELETE", f"/api/campaigns/{campaign_id}")
+
+    async def delete_campaigns(self, campaign_ids: list[int]) -> dict[str, Any]:
+        """Delete multiple campaigns by ID."""
+        params = {"id": [str(cid) for cid in campaign_ids]}
+        return await self._request("DELETE", "/api/campaigns", params=params)
+
+    async def get_running_campaign_stats(self) -> dict[str, Any]:
+        """Get stats for currently running campaigns."""
+        return await self._request("GET", "/api/campaigns/running/stats")
+
+    async def get_campaign_analytics(
+        self,
+        analytics_type: str,
+        campaign_ids: list[int],
+        from_date: str | None = None,
+        to_date: str | None = None,
+    ) -> dict[str, Any]:
+        """Get campaign analytics by type (views, clicks, links, bounces).
+
+        Args:
+            analytics_type: One of "views", "clicks", "links", "bounces".
+            campaign_ids: Campaigns to fetch analytics for.
+            from_date: Optional ISO date lower bound.
+            to_date: Optional ISO date upper bound.
+        """
+        params: dict[str, Any] = {"id": [str(cid) for cid in campaign_ids]}
+        if from_date is not None:
+            params["from"] = from_date
+        if to_date is not None:
+            params["to"] = to_date
+        return await self._request("GET", f"/api/campaigns/analytics/{analytics_type}", params=params)
+
     # Template Operations
     async def get_templates(self) -> dict[str, Any]:
         """Get all email templates."""
@@ -419,6 +724,82 @@ class ListmonkClient:
     async def delete_template(self, template_id: int) -> dict[str, Any]:
         """Delete a template."""
         return await self._request("DELETE", f"/api/templates/{template_id}")
+
+    async def set_default_template(self, template_id: int) -> dict[str, Any]:
+        """Mark a template as the default for its type."""
+        return await self._request("PUT", f"/api/templates/{template_id}/default")
+
+    async def preview_template_body(
+        self,
+        body: str,
+        template_type: str = "campaign",
+    ) -> dict[str, Any]:
+        """Render a preview of a template body without saving it."""
+        data = {"body": body, "type": template_type}
+        return await self._request("POST", "/api/templates/preview", json_data=data)
+
+    # Settings & Admin Operations
+    async def get_settings(self) -> dict[str, Any]:
+        """Get the full server settings document."""
+        return await self._request("GET", "/api/settings")
+
+    async def update_settings(self, settings: dict[str, Any]) -> dict[str, Any]:
+        """Update the full server settings document.
+
+        WARNING: GET /api/settings returns secret fields (passwords, tokens) masked
+        as bullets ("•••"). PUTting that body back overwrites the real values with
+        literal bullets. Strip secret-looking keys before calling this.
+        """
+        return await self._request("PUT", "/api/settings", json_data=settings)
+
+    async def update_setting(self, key: str, value: Any) -> dict[str, Any]:
+        """Update a single settings key (avoids the password-masking footgun)."""
+        return await self._request("PUT", f"/api/settings/{key}", json_data={"value": value})
+
+    async def test_smtp_settings(self, settings: dict[str, Any]) -> dict[str, Any]:
+        """Send a test email through provided SMTP settings."""
+        return await self._request("POST", "/api/settings/smtp/test", json_data=settings)
+
+    async def reload_app(self) -> dict[str, Any]:
+        """Trigger a hot-reload of the Listmonk app."""
+        return await self._request("POST", "/api/admin/reload")
+
+    async def get_logs(self) -> dict[str, Any]:
+        """Get recent server logs."""
+        return await self._request("GET", "/api/logs")
+
+    async def get_about_info(self) -> dict[str, Any]:
+        """Get version / build / runtime info."""
+        return await self._request("GET", "/api/about")
+
+    async def get_dashboard_counts(self) -> dict[str, Any]:
+        """Get dashboard counts (subscribers, lists, campaigns, etc)."""
+        return await self._request("GET", "/api/dashboard/counts")
+
+    async def get_dashboard_charts(self) -> dict[str, Any]:
+        """Get dashboard chart data (campaign views, link clicks over time)."""
+        return await self._request("GET", "/api/dashboard/charts")
+
+    # Maintenance Operations
+    async def gc_subscribers(self, gc_type: str) -> dict[str, Any]:
+        """Garbage collect subscribers.
+
+        Args:
+            gc_type: One of "blocklisted", "orphan", "unconfirmed".
+        """
+        return await self._request("DELETE", f"/api/maintenance/subscribers/{gc_type}")
+
+    async def gc_campaign_analytics(self, analytics_type: str) -> dict[str, Any]:
+        """Garbage collect campaign analytics ("views", "clicks", "links", "bounces", "all")."""
+        return await self._request("DELETE", f"/api/maintenance/analytics/{analytics_type}")
+
+    async def gc_unconfirmed_subscriptions(self, before: str) -> dict[str, Any]:
+        """Delete unconfirmed double-opt-in subscriptions older than the given ISO timestamp."""
+        return await self._request(
+            "DELETE",
+            "/api/maintenance/subscriptions/unconfirmed",
+            params={"before": before},
+        )
 
     # Transactional Email
     async def send_transactional_email(

--- a/src/listmonk_mcp/server.py
+++ b/src/listmonk_mcp/server.py
@@ -1055,7 +1055,10 @@ async def test_campaign(campaign_id: int, subscribers: list[str]) -> str:
 
     Args:
         campaign_id: ID of the campaign to test.
-        subscribers: One or more recipient email addresses for the test send.
+        subscribers: Recipient emails. IMPORTANT: each must already exist as a
+            subscriber on this listmonk instance (the test handler looks them
+            up by email and skips unknown addresses). Add them via
+            add_subscriber first if needed.
     """
     async def _test_campaign_logic() -> str:
         client = get_client()

--- a/src/listmonk_mcp/server.py
+++ b/src/listmonk_mcp/server.py
@@ -204,6 +204,416 @@ async def change_subscriber_status(subscriber_id: int, status: str) -> str:
     return await safe_execute_async(_change_status_logic)  # type: ignore[no-any-return]
 
 
+@mcp.tool()
+async def patch_subscriber(
+    subscriber_id: int,
+    action: str,
+    target_list_ids: list[int] | None = None,
+    status: str | None = None,
+) -> str:
+    """
+    Patch a subscriber's lists or status (more surgical than update_subscriber).
+
+    Args:
+        subscriber_id: ID of the subscriber to patch.
+        action: One of "add", "remove", "unsubscribe" (lists) or "blocklist" / "enable" (status).
+        target_list_ids: List IDs (for list-related actions).
+        status: New status (for status-related actions).
+    """
+    async def _patch_logic() -> str:
+        client = get_client()
+        await client.patch_subscriber(subscriber_id, action, target_list_ids, status)
+        return f"Successfully patched subscriber {subscriber_id} (action={action})"
+
+    return await safe_execute_async(_patch_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def subscriber_send_optin(subscriber_id: int) -> str:
+    """
+    Send a fresh opt-in confirmation email to a subscriber.
+
+    Args:
+        subscriber_id: ID of the subscriber.
+    """
+    async def _optin_logic() -> str:
+        client = get_client()
+        await client.subscriber_send_optin(subscriber_id)
+        return f"Successfully sent opt-in email to subscriber {subscriber_id}"
+
+    return await safe_execute_async(_optin_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def blocklist_subscriber(subscriber_id: int) -> str:
+    """
+    Blocklist a single subscriber (cannot be re-subscribed without manual action).
+
+    Args:
+        subscriber_id: ID of the subscriber to blocklist.
+    """
+    async def _blocklist_logic() -> str:
+        client = get_client()
+        await client.blocklist_subscriber(subscriber_id)
+        return f"Successfully blocklisted subscriber {subscriber_id}"
+
+    return await safe_execute_async(_blocklist_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def blocklist_subscribers(subscriber_ids: list[int]) -> str:
+    """
+    Blocklist multiple subscribers in one call.
+
+    Args:
+        subscriber_ids: List of subscriber IDs to blocklist.
+    """
+    async def _blocklist_many_logic() -> str:
+        client = get_client()
+        await client.blocklist_subscribers(subscriber_ids)
+        return f"Successfully blocklisted {len(subscriber_ids)} subscriber(s)"
+
+    return await safe_execute_async(_blocklist_many_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def manage_subscriber_lists(
+    subscriber_ids: list[int],
+    target_list_ids: list[int],
+    action: str,
+    status: str | None = None,
+) -> str:
+    """
+    Bulk add / remove / unsubscribe subscribers from lists.
+
+    Args:
+        subscriber_ids: Subscriber IDs to update.
+        target_list_ids: Lists to operate on.
+        action: One of "add", "remove", "unsubscribe".
+        status: Optional subscription status (e.g. "confirmed", "unconfirmed").
+    """
+    async def _manage_lists_logic() -> str:
+        client = get_client()
+        await client.manage_subscriber_lists(subscriber_ids, target_list_ids, action, status)
+        return (
+            f"Successfully {action}ed {len(subscriber_ids)} subscriber(s) "
+            f"on {len(target_list_ids)} list(s)"
+        )
+
+    return await safe_execute_async(_manage_lists_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def get_subscriber_activity(subscriber_id: int) -> str:
+    """
+    Get a subscriber's activity log (opt-ins, bounces, list changes).
+
+    Args:
+        subscriber_id: ID of the subscriber.
+    """
+    async def _activity_logic() -> str:
+        client = get_client()
+        result = await client.get_subscriber_activity(subscriber_id)
+        events = result.get("data", [])
+        if not events:
+            return f"No activity recorded for subscriber {subscriber_id}"
+        rows = [
+            f"- {e.get('created_at', '?')} | {e.get('type', '?')} | {e.get('list_name') or e.get('subject') or ''}"
+            for e in events
+        ]
+        return f"Activity for subscriber {subscriber_id} ({len(events)} events):\n" + "\n".join(rows)
+
+    return await safe_execute_async(_activity_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def delete_subscribers_by_query(query: str, list_ids: list[int] | None = None) -> str:
+    """
+    Delete subscribers matching an advanced SQL query expression.
+
+    Args:
+        query: Listmonk-style SQL query, e.g. "subscribers.status='disabled'".
+        list_ids: Optional restriction to specific list IDs.
+    """
+    async def _del_query_logic() -> str:
+        client = get_client()
+        await client.delete_subscribers_by_query(query, list_ids)
+        return f"Successfully ran query-delete (query={query!r})"
+
+    return await safe_execute_async(_del_query_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def blocklist_subscribers_by_query(query: str, list_ids: list[int] | None = None) -> str:
+    """
+    Blocklist subscribers matching an advanced SQL query expression.
+
+    Args:
+        query: Listmonk-style SQL query.
+        list_ids: Optional restriction to specific list IDs.
+    """
+    async def _bl_query_logic() -> str:
+        client = get_client()
+        await client.blocklist_subscribers_by_query(query, list_ids)
+        return f"Successfully ran query-blocklist (query={query!r})"
+
+    return await safe_execute_async(_bl_query_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def manage_subscriber_lists_by_query(
+    query: str,
+    target_list_ids: list[int],
+    action: str,
+    list_ids: list[int] | None = None,
+    status: str | None = None,
+) -> str:
+    """
+    Bulk add / remove / unsubscribe subscribers matching a query.
+
+    Args:
+        query: Listmonk-style SQL query.
+        target_list_ids: Lists to operate on.
+        action: One of "add", "remove", "unsubscribe".
+        list_ids: Optional restriction to specific source list IDs.
+        status: Optional subscription status.
+    """
+    async def _ml_query_logic() -> str:
+        client = get_client()
+        await client.manage_subscriber_lists_by_query(query, target_list_ids, action, list_ids, status)
+        return f"Successfully ran query-{action} on {len(target_list_ids)} list(s)"
+
+    return await safe_execute_async(_ml_query_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def get_subscriber_bounces(subscriber_id: int) -> str:
+    """
+    Get bounce records for a single subscriber.
+
+    Args:
+        subscriber_id: ID of the subscriber.
+    """
+    async def _sb_logic() -> str:
+        client = get_client()
+        result = await client.get_subscriber_bounces(subscriber_id)
+        bounces = result.get("data", [])
+        if not bounces:
+            return f"No bounces recorded for subscriber {subscriber_id}"
+        rows = [
+            f"- {b.get('created_at')} | {b.get('type')} | campaign {b.get('campaign_id', '-')} | {b.get('source', '?')}"
+            for b in bounces
+        ]
+        return f"Bounces for subscriber {subscriber_id} ({len(bounces)}):\n" + "\n".join(rows)
+
+    return await safe_execute_async(_sb_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def delete_subscriber_bounces(subscriber_id: int) -> str:
+    """
+    Delete all bounce records for a single subscriber.
+
+    Args:
+        subscriber_id: ID of the subscriber.
+    """
+    async def _dsb_logic() -> str:
+        client = get_client()
+        await client.delete_subscriber_bounces(subscriber_id)
+        return f"Successfully cleared bounce history for subscriber {subscriber_id}"
+
+    return await safe_execute_async(_dsb_logic)  # type: ignore[no-any-return]
+
+
+# Bounce Management Tools
+@mcp.tool()
+async def list_bounces(
+    page: int = 1,
+    per_page: int = 20,
+    campaign_id: int | None = None,
+    source: str | None = None,
+) -> str:
+    """
+    List bounce records with pagination and filtering.
+
+    Args:
+        page: Page number.
+        per_page: Page size.
+        campaign_id: Optional campaign filter.
+        source: Optional source filter (e.g. "smtp", "webhook").
+    """
+    async def _list_bounces_logic() -> str:
+        client = get_client()
+        result = await client.get_bounces(page=page, per_page=per_page, campaign_id=campaign_id, source=source)
+        data = result.get("data", {})
+        bounces = data.get("results", []) if isinstance(data, dict) else data
+        total = data.get("total", 0) if isinstance(data, dict) else len(bounces)
+
+        if not bounces:
+            return "No bounces found."
+
+        rows = []
+        for b in bounces:
+            rows.append(
+                f"- ID: {b.get('id')} | {b.get('created_at')} | {b.get('type')} | "
+                f"sub {b.get('subscriber_id')} | campaign {b.get('campaign_id', '-')} | {b.get('source', '?')}"
+            )
+        return f"Found {total} bounces (showing {len(bounces)}):\n" + "\n".join(rows)
+
+    return await safe_execute_async(_list_bounces_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def get_bounce(bounce_id: int) -> str:
+    """
+    Get a single bounce record by ID.
+
+    Args:
+        bounce_id: ID of the bounce record.
+    """
+    async def _get_bounce_logic() -> str:
+        client = get_client()
+        result = await client.get_bounce(bounce_id)
+        b = result.get("data", {})
+        return (
+            f"Bounce {b.get('id')}\n"
+            f"Subscriber: {b.get('subscriber_id')} ({b.get('email', '?')})\n"
+            f"Campaign: {b.get('campaign_id', '-')}\n"
+            f"Type: {b.get('type')}\n"
+            f"Source: {b.get('source')}\n"
+            f"Created: {b.get('created_at')}\n\n"
+            f"Meta:\n{b.get('meta', {})}"
+        )
+
+    return await safe_execute_async(_get_bounce_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def delete_bounce(bounce_id: int) -> str:
+    """
+    Delete a single bounce record.
+
+    Args:
+        bounce_id: ID of the bounce record.
+    """
+    async def _del_bounce_logic() -> str:
+        client = get_client()
+        await client.delete_bounce(bounce_id)
+        return f"Successfully deleted bounce {bounce_id}"
+
+    return await safe_execute_async(_del_bounce_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def delete_bounces(bounce_ids: list[int] | None = None) -> str:
+    """
+    Delete bounce records. Pass an empty/None list to delete ALL bounces.
+
+    Args:
+        bounce_ids: Specific IDs to delete, or None/empty to delete all.
+    """
+    async def _del_bounces_logic() -> str:
+        client = get_client()
+        await client.delete_bounces(bounce_ids)
+        if bounce_ids:
+            return f"Successfully deleted {len(bounce_ids)} bounce(s)"
+        return "Successfully deleted ALL bounces"
+
+    return await safe_execute_async(_del_bounces_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def blocklist_bounced_subscribers(bounce_ids: list[int] | None = None) -> str:
+    """
+    Blocklist subscribers who appear in specific bounces (or all bounces if empty).
+
+    Args:
+        bounce_ids: Specific bounce IDs, or None/empty to blocklist subscribers from all bounces.
+    """
+    async def _blbb_logic() -> str:
+        client = get_client()
+        await client.blocklist_bounced_subscribers(bounce_ids)
+        scope = f"{len(bounce_ids)} specified bounces" if bounce_ids else "all bounces"
+        return f"Successfully blocklisted subscribers from {scope}"
+
+    return await safe_execute_async(_blbb_logic)  # type: ignore[no-any-return]
+
+
+# Subscriber Import Tools
+@mcp.tool()
+async def import_subscribers(
+    file_path: str,
+    list_ids: list[int],
+    mode: str = "subscribe",
+    delim: str = ",",
+    overwrite: bool = True,
+    subscription_status: str = "confirmed",
+) -> str:
+    """
+    Start a subscriber import from a CSV or .zip file.
+
+    Args:
+        file_path: Absolute path to a .csv or .zip file.
+        list_ids: Lists to subscribe imported users to.
+        mode: "subscribe" (default) or "blocklist".
+        delim: CSV delimiter (default ",").
+        overwrite: Whether to overwrite existing subscribers.
+        subscription_status: "confirmed" or "unconfirmed".
+    """
+    async def _import_logic() -> str:
+        client = get_client()
+        result = await client.import_subscribers(
+            file_path=file_path,
+            mode=mode,
+            list_ids=list_ids,
+            delim=delim,
+            overwrite=overwrite,
+            subscription_status=subscription_status,
+        )
+        d = result.get("data", {})
+        return f"Import started (status={d.get('status', '?')}, total={d.get('total', '?')})"
+
+    return await safe_execute_async(_import_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def get_import_status() -> str:
+    """Get the status of the current/last subscriber import."""
+    async def _status_logic() -> str:
+        client = get_client()
+        result = await client.get_import_status()
+        d = result.get("data", {})
+        return (
+            f"Status: {d.get('status', 'none')}\n"
+            f"Total: {d.get('total', 0)}\n"
+            f"Imported: {d.get('imported', 0)}"
+        )
+
+    return await safe_execute_async(_status_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def get_import_logs() -> str:
+    """Get logs from the current/last subscriber import."""
+    async def _logs_logic() -> str:
+        client = get_client()
+        result = await client.get_import_logs()
+        return f"Import logs:\n{result.get('data', '(no logs)')}"
+
+    return await safe_execute_async(_logs_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def stop_import() -> str:
+    """Stop the currently running subscriber import."""
+    async def _stop_logic() -> str:
+        client = get_client()
+        await client.stop_import()
+        return "Successfully stopped the running import"
+
+    return await safe_execute_async(_stop_logic)  # type: ignore[no-any-return]
+
+
 # Subscriber Resources
 @mcp.resource("listmonk://subscriber/{subscriber_id}")
 async def get_subscriber_by_id(subscriber_id: str) -> str:
@@ -638,6 +1048,156 @@ async def schedule_campaign(campaign_id: int, send_at: str) -> str:
     return await safe_execute_async(_schedule_campaign_logic)  # type: ignore[no-any-return]
 
 
+@mcp.tool()
+async def test_campaign(campaign_id: int, subscribers: list[str]) -> str:
+    """
+    Send a test of a campaign to specific email addresses without affecting list members.
+
+    Args:
+        campaign_id: ID of the campaign to test.
+        subscribers: One or more recipient email addresses for the test send.
+    """
+    async def _test_campaign_logic() -> str:
+        client = get_client()
+        await client.test_campaign(campaign_id, subscribers)
+        recipients = ", ".join(subscribers)
+        return f"Successfully queued test send of campaign {campaign_id} to: {recipients}"
+
+    return await safe_execute_async(_test_campaign_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def change_campaign_status(campaign_id: int, status: str) -> str:
+    """
+    Change a campaign's status.
+
+    Args:
+        campaign_id: ID of the campaign.
+        status: One of "draft", "scheduled", "running", "paused", "cancelled".
+    """
+    async def _change_status_logic() -> str:
+        client = get_client()
+        await client.change_campaign_status(campaign_id, status)
+        return f"Successfully changed campaign {campaign_id} status to '{status}'"
+
+    return await safe_execute_async(_change_status_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def archive_campaign(
+    campaign_id: int,
+    archive: bool = True,
+    archive_template_id: int | None = None,
+    archive_meta: dict[str, Any] | None = None,
+    archive_slug: str | None = None,
+) -> str:
+    """
+    Toggle whether a campaign appears on the public archive page.
+
+    Args:
+        campaign_id: ID of the campaign.
+        archive: True to publish to archive, False to remove.
+        archive_template_id: Template to use for the archive page (optional).
+        archive_meta: Extra metadata for the archive entry (optional).
+        archive_slug: URL slug for the archive page (optional).
+    """
+    async def _archive_logic() -> str:
+        client = get_client()
+        await client.archive_campaign(
+            campaign_id,
+            archive=archive,
+            archive_template_id=archive_template_id,
+            archive_meta=archive_meta,
+            archive_slug=archive_slug,
+        )
+        verb = "archived" if archive else "unarchived"
+        return f"Successfully {verb} campaign {campaign_id}"
+
+    return await safe_execute_async(_archive_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def delete_campaign(campaign_id: int) -> str:
+    """
+    Delete a campaign permanently.
+
+    Args:
+        campaign_id: ID of the campaign to delete.
+    """
+    async def _delete_campaign_logic() -> str:
+        client = get_client()
+        await client.delete_campaign(campaign_id)
+        return f"Successfully deleted campaign {campaign_id}"
+
+    return await safe_execute_async(_delete_campaign_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def delete_campaigns(campaign_ids: list[int]) -> str:
+    """
+    Delete multiple campaigns in one call.
+
+    Args:
+        campaign_ids: List of campaign IDs to delete.
+    """
+    async def _delete_campaigns_logic() -> str:
+        client = get_client()
+        await client.delete_campaigns(campaign_ids)
+        return f"Successfully deleted {len(campaign_ids)} campaign(s): {campaign_ids}"
+
+    return await safe_execute_async(_delete_campaigns_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def get_running_campaign_stats() -> str:
+    """Get live stats for currently running campaigns (sent, to_send, rate, ETA)."""
+    async def _stats_logic() -> str:
+        client = get_client()
+        result = await client.get_running_campaign_stats()
+        data = result.get("data", [])
+        if not data:
+            return "No campaigns are currently running."
+
+        rows = []
+        for s in data:
+            rows.append(
+                f"- Campaign {s.get('id')} ({s.get('name', 'unknown')}) — "
+                f"sent: {s.get('sent', 0)}/{s.get('to_send', 0)} | "
+                f"rate: {s.get('rate', 0)}/min | "
+                f"net rate: {s.get('net_rate', 0)}/min | "
+                f"started: {s.get('started_at', 'unknown')}"
+            )
+        return f"Running campaigns ({len(data)}):\n" + "\n".join(rows)
+
+    return await safe_execute_async(_stats_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def get_campaign_analytics(
+    analytics_type: str,
+    campaign_ids: list[int],
+    from_date: str | None = None,
+    to_date: str | None = None,
+) -> str:
+    """
+    Get campaign analytics (views, clicks, links, or bounces).
+
+    Args:
+        analytics_type: One of "views", "clicks", "links", "bounces".
+        campaign_ids: Campaigns to fetch analytics for.
+        from_date: Optional ISO date lower bound (e.g. "2026-01-01").
+        to_date: Optional ISO date upper bound.
+    """
+    async def _analytics_logic() -> str:
+        client = get_client()
+        result = await client.get_campaign_analytics(
+            analytics_type, campaign_ids, from_date=from_date, to_date=to_date
+        )
+        return f"Analytics ({analytics_type}) for campaigns {campaign_ids}: {result.get('data', [])}"
+
+    return await safe_execute_async(_analytics_logic)  # type: ignore[no-any-return]
+
+
 # Campaign Resources
 @mcp.resource("listmonk://campaigns")
 async def list_campaigns() -> str:
@@ -1006,6 +1566,215 @@ async def delete_template(template_id: int) -> str:
         return f"Successfully deleted template {template_id}"
 
     return await safe_execute_async(_delete_template_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def set_default_template(template_id: int) -> str:
+    """
+    Mark a template as the default for its type.
+
+    Args:
+        template_id: ID of the template to set as default.
+    """
+    async def _set_default_logic() -> str:
+        client = get_client()
+        await client.set_default_template(template_id)
+        return f"Successfully set template {template_id} as default"
+
+    return await safe_execute_async(_set_default_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def preview_template_body(body: str, template_type: str = "campaign") -> str:
+    """
+    Render a preview of an unsaved template body.
+
+    Args:
+        body: Template HTML body.
+        template_type: One of "campaign" (default), "campaign_visual", "tx".
+    """
+    async def _preview_body_logic() -> str:
+        client = get_client()
+        result = await client.preview_template_body(body, template_type)
+        d = result.get("data", {})
+        rendered = d.get("preview") if isinstance(d, dict) else d
+        return f"# Template Preview\n\n{rendered}"
+
+    return await safe_execute_async(_preview_body_logic)  # type: ignore[no-any-return]
+
+
+# Settings & System Tools
+@mcp.tool()
+async def get_settings() -> str:
+    """
+    Get the full server settings document.
+
+    Note: secret fields (passwords, tokens) are masked as bullets in the response.
+    Do not PUT this back via update_settings — use update_setting for individual keys
+    or scrub secret-looking keys first.
+    """
+    async def _get_settings_logic() -> str:
+        client = get_client()
+        result = await client.get_settings()
+        return f"Settings:\n{result.get('data', {})}"
+
+    return await safe_execute_async(_get_settings_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def update_settings(settings: dict[str, Any]) -> str:
+    """
+    Replace the full server settings document.
+
+    WARNING: GET /api/settings masks secrets as bullets. PUTting that body back
+    overwrites real values with literal bullets. Strip any password/token/secret
+    keys from `settings` before calling this — or prefer `update_setting` for
+    a single key.
+    """
+    async def _update_settings_logic() -> str:
+        client = get_client()
+        await client.update_settings(settings)
+        return "Successfully updated settings"
+
+    return await safe_execute_async(_update_settings_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def update_setting(key: str, value: Any) -> str:
+    """
+    Update a single settings key (avoids the password-masking footgun).
+
+    Args:
+        key: Dotted setting key (e.g. "appearance.public.custom_css").
+        value: New value.
+    """
+    async def _update_one_logic() -> str:
+        client = get_client()
+        await client.update_setting(key, value)
+        return f"Successfully updated setting '{key}'"
+
+    return await safe_execute_async(_update_one_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def test_smtp_settings(settings: dict[str, Any]) -> str:
+    """
+    Send a test email through provided SMTP settings without persisting them.
+
+    Args:
+        settings: SMTP config with host/port/username/password/etc.
+    """
+    async def _test_smtp_logic() -> str:
+        client = get_client()
+        await client.test_smtp_settings(settings)
+        return "SMTP test send dispatched successfully"
+
+    return await safe_execute_async(_test_smtp_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def reload_app() -> str:
+    """Trigger a hot-reload of the Listmonk app (re-reads settings)."""
+    async def _reload_logic() -> str:
+        client = get_client()
+        await client.reload_app()
+        return "Successfully triggered app reload"
+
+    return await safe_execute_async(_reload_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def get_logs() -> str:
+    """Get recent server logs."""
+    async def _logs_logic() -> str:
+        client = get_client()
+        result = await client.get_logs()
+        return f"Logs:\n{result.get('data', '')}"
+
+    return await safe_execute_async(_logs_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def get_about_info() -> str:
+    """Get version / build / runtime info about this Listmonk instance."""
+    async def _about_logic() -> str:
+        client = get_client()
+        result = await client.get_about_info()
+        return f"About:\n{result.get('data', {})}"
+
+    return await safe_execute_async(_about_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def get_dashboard_counts() -> str:
+    """Get dashboard counts (subscribers, lists, campaigns, etc)."""
+    async def _counts_logic() -> str:
+        client = get_client()
+        result = await client.get_dashboard_counts()
+        d = result.get("data", {})
+        return f"Dashboard counts:\n{d}"
+
+    return await safe_execute_async(_counts_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def get_dashboard_charts() -> str:
+    """Get dashboard chart data (campaign views, link clicks over time)."""
+    async def _charts_logic() -> str:
+        client = get_client()
+        result = await client.get_dashboard_charts()
+        return f"Dashboard charts:\n{result.get('data', {})}"
+
+    return await safe_execute_async(_charts_logic)  # type: ignore[no-any-return]
+
+
+# Maintenance Tools
+@mcp.tool()
+async def gc_subscribers(gc_type: str) -> str:
+    """
+    Garbage collect subscribers.
+
+    Args:
+        gc_type: One of "blocklisted", "orphan", "unconfirmed".
+    """
+    async def _gc_subs_logic() -> str:
+        client = get_client()
+        await client.gc_subscribers(gc_type)
+        return f"Successfully ran subscriber GC ({gc_type})"
+
+    return await safe_execute_async(_gc_subs_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def gc_campaign_analytics(analytics_type: str) -> str:
+    """
+    Garbage collect campaign analytics.
+
+    Args:
+        analytics_type: One of "views", "clicks", "links", "bounces", "all".
+    """
+    async def _gc_analytics_logic() -> str:
+        client = get_client()
+        await client.gc_campaign_analytics(analytics_type)
+        return f"Successfully ran analytics GC ({analytics_type})"
+
+    return await safe_execute_async(_gc_analytics_logic)  # type: ignore[no-any-return]
+
+
+@mcp.tool()
+async def gc_unconfirmed_subscriptions(before: str) -> str:
+    """
+    Delete unconfirmed double-opt-in subscriptions older than the given timestamp.
+
+    Args:
+        before: ISO timestamp; subscriptions created before this are removed.
+    """
+    async def _gc_unconfirmed_logic() -> str:
+        client = get_client()
+        await client.gc_unconfirmed_subscriptions(before)
+        return f"Successfully GC'd unconfirmed subscriptions before {before}"
+
+    return await safe_execute_async(_gc_unconfirmed_logic)  # type: ignore[no-any-return]
 
 
 @mcp.tool()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -326,7 +326,7 @@ wheels = [
 
 [[package]]
 name = "listmonk-mcp"
-version = "0.0.12"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Adds wrappers for every operational Listmonk REST endpoint that was missing from the MCP, bringing total tool count from ~40 to **70**. Skips admin-user / roles / 2FA endpoints since those make more sense in the web UI than via an MCP.

## What's new

**Campaign lifecycle (7)** — `test_campaign`, `change_campaign_status`, `archive_campaign`, `delete_campaign`, `delete_campaigns`, `get_running_campaign_stats`, `get_campaign_analytics`

**Subscribers (11)** — `patch_subscriber`, `subscriber_send_optin`, `blocklist_subscriber`, `blocklist_subscribers`, `manage_subscriber_lists`, `get_subscriber_activity`, `delete_subscribers_by_query`, `blocklist_subscribers_by_query`, `manage_subscriber_lists_by_query`, `get_subscriber_bounces`, `delete_subscriber_bounces`

**Bounces (5)** — `list_bounces`, `get_bounce`, `delete_bounce`, `delete_bounces` (with an all-flag for nuking everything), `blocklist_bounced_subscribers`

**Subscriber import (4)** — `import_subscribers` (multipart CSV/zip upload), `get_import_status`, `get_import_logs`, `stop_import`

**Templates (2)** — `set_default_template`, `preview_template_body`

**Settings & system (9)** — `get_settings`, `update_settings`, `update_setting`, `test_smtp_settings`, `reload_app`, `get_logs`, `get_about_info`, `get_dashboard_counts`, `get_dashboard_charts`

**Maintenance (3)** — `gc_subscribers`, `gc_campaign_analytics`, `gc_unconfirmed_subscriptions`

## Two listmonk-API quirks worth flagging

1. **`POST /api/campaigns/{id}/test` requires the full campaign payload, not just subscribers.** Sending `{"subscribers": [...]}` alone fails with `Invalid length for name` because the handler runs `validateCampaignFields` on the whole body (name, subject, lists, body, messenger, content_type). The client method now fetches the saved campaign and merges those fields — same pattern `update_campaign` already uses.

2. **`PUT /api/settings/{key}` reads the body as a raw JSON value, NOT `{"value": ...}`.** Wrapping silently stores the wrapper object under the key and breaks the field. Documented in the docstring; the per-key tool sends the value directly.

## Code style

All new client methods follow the existing `httpx`-based pattern with typed parameters and JSON-data payloads. All new tools use the existing `safe_execute_async` wrapper for consistent error handling. Loosens `_request`'s `json_data` parameter type from `dict` to `Any` since httpx's `json=` argument accepts any JSON-serialisable value (needed for the per-key settings endpoint).

## Verification

- ✅ ruff: clean
- ✅ mypy strict: clean (`Success: no issues found in 6 source files`)
- ✅ Smoke-tested against a live Listmonk instance: about / dashboard counts / running stats / bounces / settings / analytics all return the expected shapes; analytics correctly rejects empty campaign-id list with the same `Missing field(s): id` message the web UI shows
- ✅ End-to-end test: `test_campaign` delivered a real test email, response `{"data": true}`

## Version

Bumps `0.1.0 → 0.2.0`.

## Notes

Happy to split this into multiple PRs by area if that's easier to review — the commits are organised so each area's client methods + tools can be cherry-picked. Let me know either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)